### PR TITLE
fix error in lint.c

### DIFF
--- a/lint/lint.c
+++ b/lint/lint.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdint.h>
 
 typedef uint8_t  u8;
 typedef uint16_t u16;


### PR DESCRIPTION
On my install on non ARM hardware it threw the following error:
```
lint/lint.c:7:9: error: unknown type name ‘uint8_t’
    7 | typedef uint8_t  u8;
      |         ^~~~~~~
lint/lint.c:8:9: error: unknown type name ‘uint16_t’
    8 | typedef uint16_t u16;
      |         ^~~~~~~~
lint/lint.c:9:9: error: unknown type name ‘uint32_t’
    9 | typedef uint32_t u32;
      |         ^~~~~~~~
lint/lint.c:10:9: error: unknown type name ‘uint64_t’
   10 | typedef uint64_t u64;
      |         ^~~~~~~~
lint/lint.c:11:9: error: unknown type name ‘int8_t’
   11 | typedef int8_t   i8;
      |         ^~~~~~
lint/lint.c:12:9: error: unknown type name ‘int16_t’
   12 | typedef int16_t  i16;
      |         ^~~~~~~
lint/lint.c:13:9: error: unknown type name ‘int32_t’
   13 | typedef int32_t  i32;
      |         ^~~~~~~
lint/lint.c:14:9: error: unknown type name ‘int64_t’
   14 | typedef int64_t  i64;
   ```
   It was fixed by the inclusion of `stdint.h` in lint.c