### PR TITLE
replace 'sub ax,2' with two times 'dec ax',

### DIFF
--- a/sectorc.s
+++ b/sectorc.s
@@ -114,7 +114,8 @@ compile_stmts:
 
   mov ax,[bx]                   ; load function offset from symbol-table
   sub ax,di                     ; compute relative to this location: "dest - cur - 2"
-  sub ax,2
+  dec ax                        ; (shorter than 'sub ax,2')
+  dec ax
   stosw                         ;  emit target
 
   jmp compile_stmts_tok_next2   ; loop to compile next statement
@@ -148,7 +149,8 @@ _patch_back:
   stosb
   pop ax                        ; restore loop start location
   sub ax,di                     ; compute relative to this location: "dest - cur - 2"
-  sub ax,2
+  dec ax                        ; (shorter than 'sub ax,2')
+  dec ax
   stosw                         ; emit target
   ;; [fall-through]
 _patch_fwd:


### PR DESCRIPTION
which is 1 byte shorter. Doing this in 2 places
safes 2 bytes which leads to a 489 bytes flat binary.