### PR TITLE
Add character literal support

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ unary       = deref identifier
             | "(" expr ")"
             | identifier
             | integer
+            | char_literal
+char_literal = "'" <character> "'"
 op          = "+" | "-" | "&" | "|" | "^" | "<<" | ">>"
             | "==" | "!=" | "<" | ">" | "<=" | ">="
 ```

--- a/examples/test_char_literals.c
+++ b/examples/test_char_literals.c
@@ -1,0 +1,36 @@
+int ch;
+
+void test_char_literals()
+{
+  ch = 'H';
+  print_char();
+  ch = 'e';
+  print_char();
+  ch = 'l';
+  print_char();
+  ch = 'l';
+  print_char();
+  ch = 'o';
+  print_char();
+  ch = ' ';
+  print_char();
+  ch = 'W';
+  print_char();
+  ch = 'o';
+  print_char();
+  ch = 'r';
+  print_char();
+  ch = 'l';
+  print_char();
+  ch = 'd';
+  print_char();
+  ch = '!';
+  print_char();
+  print_newline();
+}
+
+void _start()
+{
+  test_char_literals();
+  while( 1 ){ }
+}

--- a/lint/lint.c
+++ b/lint/lint.c
@@ -273,6 +273,21 @@ static void tok_next(void)
       continue;
     }
 
+    // Handle character literal
+    if (c == '\'') {
+      tok_char_next();
+      c = tok_char_get();
+      tok->type = TOK_TYPE_NUM;
+      tok->text = input_ptr - 1;
+      tok->len = 3;
+      tok->val = c;
+      tok_char_next();
+      c = tok_char_get();
+      if (c != '\'') error("expected closing quote for character literal");
+      tok_char_next();
+      return;
+    }
+
     tok->type = ('0' <= c && c <= '9') ? TOK_TYPE_NUM : TOK_TYPE_SYM;
     tok->text = input_ptr;
     tok->len = 1;

--- a/sectorc.s
+++ b/sectorc.s
@@ -324,6 +324,9 @@ tok_next:
   cmp al,32                     ; skip spaces (anything <= ' ' is considered space)
   jle tok_next
 
+  cmp al,39                     ; check for single quote (character literal)
+  je _char_literal
+
   xor bx,bx                     ; zero token reg
   xor cx,cx                     ; zero last-two chars reg
 
@@ -354,6 +357,15 @@ _done:
   sete dh
 
   mov ax,bx                     ; return token in ax also
+  ret
+
+_char_literal:
+  call getch                    ; get the character inside quotes
+  xor ah,ah                     ; zero high byte of ax
+  mov bx,ax                     ; bx = character value
+  call getch                    ; consume closing quote
+  mov dl,1                      ; tok_is_num = true (treat as number)
+  mov ax,bx                     ; return value in ax
   ret
 
 _comment_double_slash:


### PR DESCRIPTION
This adds support for character literals using single quotes. Example: 'A' instead of 65

Implementation:
- Detects single quote (') in tokenizer
- Reads the character and returns its ASCII value
- Treats character literals as numeric tokens
- Updates linter to recognize and validate character literals
- Updates grammar documentation
- Adds test example demonstrating character literals

Impact: Still fits within 512-byte boot sector
The feature adds approximately 18 bytes of code, which fits comfortably in the available space.